### PR TITLE
Draft: Restore plugin for 2025.*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.1.8]
+
+### Changed
+
+- Updated to support IntelliJ IDEs up to 2025.*
+- Upgraded Java version to 17
+- Updated Gradle and Kotlin plugin versions
+- Set minimum supported IDE version to 2024.1
+- Removed `untilBuild` cap on version
+
 ## [0.1.7]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-![](docs/logo.png)
+<!-- Plugin description -->
+<p><img src="https://raw.githubusercontent.com/nils-degroot/srcery-intellij/master/docs/logo.png" width="600" /></p>
+<p>Colorscheme with clearly defined contrasting colors and a slightly earthy tone.</p>
+<p>Based on <a href="https://srcery-colors.github.io/">https://srcery-colors.github.io/</a></p>
+<h2>Installation</h2>
+<p>Installation can be done via
+the <a href="https://plugins.jetbrains.com/plugin/18428-srcery-colorscheme/">JetBrains plugin manager</a></p>
+<h2>Screenshots</h2>
+<p><img src="https://raw.githubusercontent.com/nils-degroot/srcery-intellij/master/docs/screenshot.png" width="600" /></p>
 
 Colorscheme with clearly defined contrasting colors and a slightly earthy tone.
 
 Based on [https://srcery-colors.github.io/](https://srcery-colors.github.io/)
-
-## Installation
-
-Installation can be done via
-the [JetBrains plugin manager](https://plugins.jetbrains.com/plugin/18428-srcery-colorscheme/)
-
-## Screenshots
-
-![](docs/screenshot.png)
+<!-- Plugin description end -->

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,84 +1,163 @@
-import org.jetbrains.changelog.date
-import org.jetbrains.intellij.tasks.RunPluginVerifierTask
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
-fun properties(key: String) = project.findProperty(key).toString()
+import org.jetbrains.changelog.Changelog
+import org.jetbrains.changelog.markdownToHTML
+import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 
 plugins {
-    id("java")
-    id("org.jetbrains.kotlin.jvm") version "1.4.0"
-    id("org.jetbrains.intellij") version "1.0"
-    id("org.jetbrains.changelog") version "1.3.1"
+    id("java") // Java support
+    alias(libs.plugins.kotlin) // Kotlin support
+    alias(libs.plugins.intelliJPlatform) // IntelliJ Platform Gradle Plugin
+    alias(libs.plugins.changelog) // Gradle Changelog Plugin
+    alias(libs.plugins.qodana) // Gradle Qodana Plugin
+    alias(libs.plugins.kover) // Gradle Kover Plugin
 }
 
-group = properties("pluginGroup")
-version = properties("pluginVersion")
+group = providers.gradleProperty("pluginGroup").get()
+version = providers.gradleProperty("pluginVersion").get()
 
-intellij {
-    pluginName.set(properties("pluginName"))
-    version.set(properties("platformVersion"))
-    type.set(properties("platformType"))
+// Set the JVM language level used to build the project.
+kotlin {
+    jvmToolchain(21)
 }
 
+// Configure project's dependencies
 repositories {
     mavenCentral()
+
+    // IntelliJ Platform Gradle Plugin Repositories Extension - read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-repositories-extension.html
+    intellijPlatform {
+        defaultRepositories()
+    }
 }
 
+// Dependencies are managed with Gradle version catalog - read more: https://docs.gradle.org/current/userguide/platforms.html#sub:version-catalog
+dependencies {
+    testImplementation(libs.junit)
+    testImplementation(libs.opentest4j)
+
+    // IntelliJ Platform Gradle Plugin Dependencies Extension - read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html
+    intellijPlatform {
+        create(providers.gradleProperty("platformType"), providers.gradleProperty("platformVersion"))
+
+        // Plugin Dependencies. Uses `platformBundledPlugins` property from the gradle.properties file for bundled IntelliJ Platform plugins.
+        bundledPlugins(providers.gradleProperty("platformBundledPlugins").map { it.split(',') })
+
+        // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file for plugin from JetBrains Marketplace.
+        plugins(providers.gradleProperty("platformPlugins").map { it.split(',') })
+
+        testFramework(TestFrameworkType.Platform)
+    }
+}
+
+// Configure IntelliJ Platform Gradle Plugin - read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-extension.html
+intellijPlatform {
+    pluginConfiguration {
+        name = providers.gradleProperty("pluginName")
+        version = providers.gradleProperty("pluginVersion")
+
+        // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
+        description = providers.fileContents(layout.projectDirectory.file("README.md")).asText.map {
+            val start = "<!-- Plugin description -->"
+            val end = "<!-- Plugin description end -->"
+
+            with(it.lines()) {
+                if (!containsAll(listOf(start, end))) {
+                    throw GradleException("Plugin description section not found in README.md:\n$start ... $end")
+                }
+                subList(indexOf(start) + 1, indexOf(end)).joinToString("\n").let(::markdownToHTML)
+            }
+        }
+
+        val changelog = project.changelog // local variable for configuration cache compatibility
+        // Get the latest available change notes from the changelog file
+        changeNotes = providers.gradleProperty("pluginVersion").map { pluginVersion ->
+            with(changelog) {
+                renderItem(
+                    (getOrNull(pluginVersion) ?: getUnreleased())
+                        .withHeader(false)
+                        .withEmptySections(false),
+                    Changelog.OutputType.HTML,
+                )
+            }
+        }
+
+        ideaVersion {
+            sinceBuild = providers.gradleProperty("pluginSinceBuild")
+//            untilBuild = providers.gradleProperty("pluginUntilBuild")
+            untilBuild = provider { null }
+        }
+    }
+
+    signing {
+        certificateChain = providers.environmentVariable("CERTIFICATE_CHAIN")
+        privateKey = providers.environmentVariable("PRIVATE_KEY")
+        password = providers.environmentVariable("PRIVATE_KEY_PASSWORD")
+    }
+
+    publishing {
+        token = providers.environmentVariable("PUBLISH_TOKEN")
+        // The pluginVersion is based on the SemVer (https://semver.org) and supports pre-release labels, like 2.1.7-alpha.3
+        // Specify pre-release label to publish the plugin in a custom Release Channel automatically. Read more:
+        // https://plugins.jetbrains.com/docs/intellij/deployment.html#specifying-a-release-channel
+        channels = providers.gradleProperty("pluginVersion").map { listOf(it.substringAfter('-', "").substringBefore('.').ifEmpty { "default" }) }
+    }
+
+    pluginVerification {
+        ides {
+            recommended()
+        }
+    }
+}
+
+// Configure Gradle Changelog Plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
 changelog {
-    version.set(properties("pluginVersion"))
-    path.set("${project.projectDir}/CHANGELOG.md")
-    header.set(provider { "[${version.get()}] - ${date()}" })
-    itemPrefix.set("-")
-    groups.set(listOf("Added", "Changed"))
+    groups.empty()
+    repositoryUrl = providers.gradleProperty("pluginRepositoryUrl")
+}
+
+// Configure Gradle Kover Plugin - read more: https://github.com/Kotlin/kotlinx-kover#configuration
+kover {
+    reports {
+        total {
+            xml {
+                onCheck = true
+            }
+        }
+    }
 }
 
 tasks {
-    properties("javaVersion").let {
-        withType<JavaCompile> {
-            sourceCompatibility = it
-            targetCompatibility = it
-        }
-        withType<KotlinCompile> {
-            kotlinOptions.jvmTarget = it
-        }
-    }
-
     wrapper {
-        gradleVersion = properties("gradleVersion")
-    }
-
-    patchPluginXml {
-        version.set(properties("pluginVersion"))
-        sinceBuild.set(properties("pluginSinceBuild"))
-        untilBuild.set(properties("pluginUntilBuild"))
-        pluginDescription.set("""
-            |<p><img src="https://raw.githubusercontent.com/nils-degroot/srcery-intellij/master/docs/logo.png" width="600" /></p>
-            |<p>Colorscheme with clearly defined contrasting colors and a slightly earthy tone.</p>
-            |<p>Based on <a href="https://srcery-colors.github.io/">https://srcery-colors.github.io/</a></p>
-            |<h2>Installation</h2>
-            |<p>Installation can be done via
-            |the <a href="https://plugins.jetbrains.com/plugin/18428-srcery-colorscheme/">JetBrains plugin manager</a></p>
-            |<h2>Screenshots</h2>
-            |<p><img src="https://raw.githubusercontent.com/nils-degroot/srcery-intellij/master/docs/screenshot.png" width="600" /></p>
-        """.trimMargin())
-        changeNotes.set(provider { changelog.getLatest().toHTML() })
-    }
-
-    runPluginVerifier {
-        ideVersions.set(
-            properties("pluginVerifierIdeVersions")
-                .split(",")
-                .map { it.trim() }
-                .filter { it.isNotEmpty() }
-        )
-
-        failureLevel.set(listOf(
-            RunPluginVerifierTask.FailureLevel.COMPATIBILITY_PROBLEMS,
-            RunPluginVerifierTask.FailureLevel.INVALID_PLUGIN
-        ))
+        gradleVersion = providers.gradleProperty("gradleVersion").get()
     }
 
     publishPlugin {
-        token.set(System.getenv("SRCERY_INTELLIJ_TOKEN"))
+        dependsOn(patchChangelog)
+    }
+}
+
+intellijPlatformTesting {
+    runIde {
+        register("runIdeForUiTests") {
+            task {
+                jvmArgumentProviders += CommandLineArgumentProvider {
+                    listOf(
+                        "-Drobot-server.port=8082",
+                        "-Dide.mac.message.dialogs.as.sheets=false",
+                        "-Djb.privacy.policy.text=<!--999.999-->",
+                        "-Djb.consents.confirmation.enabled=false",
+                    )
+                }
+            }
+
+            plugins {
+                robotServerPlugin()
+            }
+        }
+    }
+}
+
+tasks {
+    test {
+        enabled = true
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,16 +1,31 @@
 pluginGroup = com.nils-degroot.srcery-theme
 pluginName = Srcery Colorscheme
-pluginVersion = 0.1.7
+pluginVersion = 0.1.8
+pluginRepositoryUrl = https://github.com/srcery-colors/srcery-intellij
 
-pluginSinceBuild = 203
-pluginUntilBuild = 232.*
+# Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
+pluginSinceBuild = 251
+# pluginUntilBuild is not required as untilBuild setting in the build.gradle.kts is commented out. No cap on the upper version
+#pluginUntilBuild = 252.*
 
-platformVersion = 2021.3
-platformType = IC
+# IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
+platformType = IU
+platformVersion = 2025.1.1
 
-javaVersion = 11
-gradleVersion = 7.3
+# Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
+# Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP
+platformPlugins =
+# Example: platformBundledPlugins = com.intellij.java
+platformBundledPlugins =
 
-pluginVerifierIdeVersions = 2020.2.4, 2020.3.4, 2021.1.1, 2022.2, 2022.3, 2023.1, 2023.2
+# Gradle Releases -> https://github.com/gradle/gradle/releases
+gradleVersion = 8.13
 
+# Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency = false
+
+# Enable Gradle Configuration Cache -> https://docs.gradle.org/current/userguide/configuration_cache.html
+org.gradle.configuration-cache = true
+
+# Enable Gradle Build Cache -> https://docs.gradle.org/current/userguide/build_cache.html
+org.gradle.caching = true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,22 @@
+[versions]
+# libraries
+junit = "4.13.2"
+opentest4j = "1.3.0"
+
+# plugins
+changelog = "2.2.1"
+intelliJPlatform = "2.5.0"
+kotlin = "2.1.20"
+kover = "0.9.1"
+qodana = "2024.3.4"
+
+[libraries]
+junit = { group = "junit", name = "junit", version.ref = "junit" }
+opentest4j = { group = "org.opentest4j", name = "opentest4j", version.ref = "opentest4j" }
+
+[plugins]
+changelog = { id = "org.jetbrains.changelog", version.ref = "changelog" }
+intelliJPlatform = { id = "org.jetbrains.intellij.platform", version.ref = "intelliJPlatform" }
+kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
+qodana = { id = "org.jetbrains.qodana", version.ref = "qodana" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,5 @@
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+}
+
 rootProject.name = "Srcery Colorscheme"


### PR DESCRIPTION
Refreshed Gradle configuration and removed limit on upper build number. Note: the publishing token has to be provided via `PUBLISH_TOKEN` env.